### PR TITLE
Add get host to kernel terminate event

### DIFF
--- a/src/M6Web/Component/HttpKernel/Event/KernelTerminateEvent.php
+++ b/src/M6Web/Component/HttpKernel/Event/KernelTerminateEvent.php
@@ -15,7 +15,7 @@ class KernelTerminateEvent extends Event
 
     /**
      * constructeur
-     * 
+     *
      * @param Request $request   request
      * @param int     $code      code
      * @param float   $startTime start time en ms
@@ -85,4 +85,13 @@ class KernelTerminateEvent extends Event
         return 0;
     }
 
+    /**
+     * retourne le host
+     *
+     * @return string
+     */
+    public function getHost()
+    {
+        return str_replace('.', '_', $this->request->getHost());
+    }
 }


### PR DESCRIPTION
Need host information to statsd monitoring. 
So add `getHost` to event kernel terminate.