### PR TITLE
Fix unquoted param references

### DIFF
--- a/src/M6Web/Bundle/HttpKernelBundle/Resources/config/services.yml
+++ b/src/M6Web/Bundle/HttpKernelBundle/Resources/config/services.yml
@@ -4,14 +4,14 @@ parameters:
 
 services:
     m6.kernel.exception.listener:
-        class: %m6.kernel.exception.listener.class%
+        class: '%m6.kernel.exception.listener.class%'
         arguments:
             - "@event_dispatcher"
         tags:
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException}
 
     m6.kernel.terminate.listener:
-        class: %m6.kernel.terminate.listener.class%
+        class: '%m6.kernel.terminate.listener.class%'
         arguments:
             - "@event_dispatcher"
             - "@service_container"


### PR DESCRIPTION
Compatibility with Symfony 3.1