### PR TITLE
KernelTerminateEvent's request attribute public

### DIFF
--- a/src/M6Web/Component/HttpKernel/Event/KernelTerminateEvent.php
+++ b/src/M6Web/Component/HttpKernel/Event/KernelTerminateEvent.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class KernelTerminateEvent extends Event
 {
-    private $request;
+    public $request;
     private $code;
     private $startTime;
 


### PR DESCRIPTION
## Why
To keep backward compatibility... because, the attribute wasn't defined before v1.1.2, which was equal to having the attribute as `public`